### PR TITLE
chore: [LINKER-15] 로드밸런서 서버설정에 맞도록 도커 컨테이너의 외부 port를 3000번으로 변경

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,4 +53,4 @@ jobs:
               sudo docker rm linker
           fi &&
           sudo docker image pull 903755389667.dkr.ecr.ap-northeast-2.amazonaws.com/linker:$IMAGE_TAG &&
-          sudo docker container run --name linker -d -p 80:3000 903755389667.dkr.ecr.ap-northeast-2.amazonaws.com/linker:$IMAGE_TAG"
+          sudo docker container run --name linker -d -p 3000:3000 903755389667.dkr.ecr.ap-northeast-2.amazonaws.com/linker:$IMAGE_TAG"


### PR DESCRIPTION
## 작업 내용

<!-- 작업한 내용을 적어주세요 -->

### from aws
- AWS CM에서 certificate 발급
- aws 로드밸런서 생성 및 발급받은 인증서 적용
- route53에서 기존에 ec2와 연결되어 있던 레코드를 로드밸런서와 연결되도록 변경

### from this PR
- 도커 컨테이너 실행시 외부로 뚫는 port를 3000번으로 변경
> 보안상 80을 직접 뚫는것은 위험. 따라서 ec2내에서 실행되는 도커 컨테이너는 3000번을 사용하고 로드밸런서 레벨에서 인입되는 트래픽을 3000번 port로 redirect하도록 설정함

<br />

## 반영 화면

<!-- 작업 내용이 반영된 화면을 붙여넣어주세요 -->

<!--

| **AS-IS** | **TO-BE** |
|:---:|:---:|
| x | y |

영상
<video src="" style="width:25%;" />

이미지
<img src="" style="width:25%;" /> 

-->


<br />

## 기타

- n/a
