### PR TITLE
fix: [LINKER-38] 도커 이미지 충돌 해결 

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -73,6 +73,7 @@ jobs:
         run: |
           echo "${{ secrets.EC2_SSH_PRIVATE_KEY }}" > private_key.pem
           chmod 600 private_key.pem
+          NEW_CONTAINER_NAME="linker_${IMAGE_TAG}"
           ssh -i private_key.pem -o StrictHostKeyChecking=no ubuntu@$EC2_IP "
           aws ecr get-login-password --region ap-northeast-2 |
           sudo docker login --username AWS --password-stdin 903755389667.dkr.ecr.ap-northeast-2.amazonaws.com/linker &&


### PR DESCRIPTION
## 작업 내용

### 서비스가 내려감
![스크린샷 2023-12-23 오전 12 03 21](https://github.com/YAPP-Github/23rd-Web-Team-1-FE/assets/75570915/0d4f81f9-6904-4a4b-a45a-a9d4ee8c6c66)


<!-- 작업한 내용을 적어주세요 -->

### github action Error 
![스크린샷 2023-12-22 오후 11 40 23](https://github.com/YAPP-Github/23rd-Web-Team-1-FE/assets/75570915/d5b6c9bb-c710-4ffd-b57d-3aead1fe50c6)

[원인]
- github action CI: Deploy to EC2 실행 > 도커 이미지 충돌 에러 발생
- (추측) cleanup 할 때 cleanup용 도커 이미지를 생성하고, 그걸 그대로 가져다가 쓰는거 같음

[시도]
-  Deploy to EC2 실행 될 때 새로운 도커 컨테이너 이름을 생성해서 충돌 피하기

<br />

## 반영 화면

<!-- 작업 내용이 반영된 화면을 붙여넣어주세요 -->

<!--

| **AS-IS** | **TO-BE** |
|:---:|:---:|
| x | y |

영상
<video src="" style="width:25%;" />

이미지
<img src="" style="width:25%;" /> 

-->


<br />

## 기타

- 
