### PR TITLE
fix: docker build시 arm64 호환 에러발생하는 이슈 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # node.js 압축 이미지를 설치합니다
-FROM node:18.17.0-alpine as BUILD
+FROM node:18.17.0-slim as BUILD
 
 # yarn 설치
 RUN npm install -g yarn --force
@@ -17,7 +17,7 @@ RUN yarn workspaces focus && \
 
 RUN yarn install
 
-RUN /bin/sh -c yarn workspace web build
+RUN yarn workspace web build
 
 FROM node:18.17.0-alpine
 EXPOSE 3000


### PR DESCRIPTION
## 작업 내용

<!-- 작업한 내용을 적어주세요 -->


기존에 docker에서 build하여 container를 실행시 아래와 같은 에러가 발생했음
```
   ▲ Next.js 14.0.3
   - Local:        http://localhost:3000

[Error: ENOENT: no such file or directory, open '/app/services/web/.next/BUILD_ID'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/app/services/web/.next/BUILD_ID'
}
```
해당 에러에 대한 원인은 파악하지 못했으나 Dockerfile에서 `RUN /bin/sh -c yarn workspace web build`와 같은 명령어를 실행해서 발생하는 문제로 추측함.
하지만 `RUN yarn workspace web build` 이렇게 명령어를 실행시 아래와 같은 에러가 발생함

```
[+] Building 12.1s (12/14)                                                                                                                                                                                                                                  docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                        0.0s
 => => transferring dockerfile: 490B                                                                                                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                           0.0s
 => => transferring context: 58B                                                                                                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/node:18.17.0-alpine                                                                                                                                                                                                      2.6s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                                                                                                                                                 0.0s
 => [internal] load build context                                                                                                                                                                                                                                           0.3s
 => => transferring context: 732.75kB                                                                                                                                                                                                                                       0.2s
 => [build 1/7] FROM docker.io/library/node:18.17.0-alpine@sha256:58878e9e1ed3911bdd675d576331ed8838fc851607aed3bb91e25dfaffab3267                                                                                                                                          0.0s
 => CACHED [build 2/7] RUN npm install -g yarn --force                                                                                                                                                                                                                      0.0s
 => CACHED [build 3/7] WORKDIR /app                                                                                                                                                                                                                                         0.0s
 => CACHED [build 4/7] COPY . .                                                                                                                                                                                                                                             0.0s
 => CACHED [build 5/7] RUN yarn set version 4.0.2                                                                                                                                                                                                                           0.0s
 => [build 6/7] RUN yarn install                                                                                                                                                                                                                                            5.8s
 => ERROR [build 7/7] RUN yarn workspace web build                                                                                                                                                                                                                          3.4s 
------                                                                                                                                                                                                                                                                           
 > [build 7/7] RUN yarn workspace web build:                                                                                                                                                                                                                                     
1.653 Attention: Next.js now collects completely anonymous telemetry regarding usage.                                                                                                                                                                                            
1.653 This information is used to shape Next.js' roadmap and prioritize features.                                                                                                                                                                                                
1.653 You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:                                                                                                                                    
1.653 https://nextjs.org/telemetry
1.653 
1.708    ▲ Next.js 14.0.3
1.708 
1.708    Creating an optimized production build ...
1.783  ⚠ Attempted to load @next/swc-linux-arm64-gnu, but an error occurred: Error relocating /app/.yarn/unplugged/@next-swc-linux-arm64-gnu-npm-14.0.3-88013eafad/node_modules/@next/swc-linux-arm64-gnu/next-swc.linux-arm64-gnu.node: __res_init: symbol not found
1.783  ⚠ Attempted to load @next/swc-linux-arm64-musl, but it was not installed
3.303  ⨯ Failed to load SWC binary for linux/arm64, see more info here: https://nextjs.org/docs/messages/failed-loading-swc
------
Dockerfile:16
--------------------
  14 |     RUN yarn install
  15 |     
  16 | >>> RUN yarn workspace web build
  17 |     
  18 |     FROM node:18.17.0-alpine
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn workspace web build" did not complete successfully: exit code: 1
```

이는 arm64 호환 관련해서 충돌이 발생한 문제로 보여서 node의 이미지 버전을 alpine => slim으로 변경

<br />

## 반영 화면

<!-- 작업 내용이 반영된 화면을 붙여넣어주세요 -->

<!--

| **AS-IS** | **TO-BE** |
|:---:|:---:|
| x | y |

영상
<video src="" style="width:25%;" />

이미지
<img src="" style="width:25%;" /> 

-->


<br />

## 기타

- n/a
