### PR TITLE
fix: [LINKER-84] dev:mock 실행 명령어 오류 해결

### DIFF
--- a/packages/ky/index.ts
+++ b/packages/ky/index.ts
@@ -1,4 +1,3 @@
-import kyInstance, { createKyApis, prefix } from './kyInstance';
+import kyInstance, { createKyApis } from './kyInstance';
 
 export const ky = createKyApis(kyInstance);
-export const API_URL = prefix;

--- a/packages/ky/tsconfig.json
+++ b/packages/ky/tsconfig.json
@@ -12,24 +12,10 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
+    "outDir": "dist",
     "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "baseUrl": ".",
-    "paths": {
-      "@*": ["./src/*"]
-    }
+    "preserveValueImports": false
   },
-  "include": [
-    "next-env.d.ts",
-    "./src/**/*.tsx",
-    "./src/**/*.ts",
-    "./jest.config.ts",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": ["node_modules"]
+  "include": ["./**/*.ts"]
 }

--- a/services/web/package.json
+++ b/services/web/package.json
@@ -6,7 +6,6 @@
     "dev": "next dev",
     "mock": "ts-node ./src/__server__/http.ts",
     "dev:mock": "concurrently --kill-others \"yarn dev\" \"yarn mock\"",
-
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/services/web/src/__server__/constants.ts
+++ b/services/web/src/__server__/constants.ts
@@ -1,0 +1,1 @@
+export const MOCK_API_URL = 'http://localhost:8000';

--- a/services/web/src/__server__/mockApi.ts
+++ b/services/web/src/__server__/mockApi.ts
@@ -1,6 +1,7 @@
-import { API_URL } from '@linker/ky';
 import { DefaultBodyType, http, HttpResponse, PathParams, ResponseResolver } from 'msw';
 import { HttpRequestResolverExtras } from 'msw/lib/core/handlers/HttpHandler';
+
+import { MOCK_API_URL } from './constants';
 
 type Resolver = ResponseResolver<HttpRequestResolverExtras<PathParams>> | DefaultBodyType;
 
@@ -15,7 +16,7 @@ export const mockApi: MockApi = new Proxy({} as MockApi, {
     }
 
     return (endpoint: string, resolver: Resolver) => {
-      const url = `${API_URL}${endpoint}`;
+      const url = `${MOCK_API_URL}${endpoint}`;
 
       return http[key as keyof typeof http](url, (info) => {
         if (typeof resolver !== 'function') {

--- a/services/web/src/__server__/mocks/feed.ts
+++ b/services/web/src/__server__/mocks/feed.ts
@@ -1,13 +1,14 @@
 /* eslint-disable max-len */
-import { API_URL } from '@linker/ky';
 import { http, HttpResponse } from 'msw';
 
+import { MOCK_API_URL } from '../constants';
+
 export const feedHandlers = [
-  http.get(`${API_URL}/v1/my`, () => {
+  http.get(`${MOCK_API_URL}/v1/my`, () => {
     return HttpResponse.json({ data: my }, { status: 200 });
   }),
 
-  http.get(`${API_URL}/v1/schedules/upcoming/recommendation`, () => {
+  http.get(`${MOCK_API_URL}/v1/schedules/upcoming/recommendation`, () => {
     return HttpResponse.json({ data: upcomingSchedules }, { status: 200 });
   }),
 ];


### PR DESCRIPTION
## 작업 내용

<!-- 작업한 내용을 적어주세요 -->

### yarn dev:mock으로 실행했을 경우 오류 발생
<img width="1031" alt="errors" src="https://github.com/YAPP-Github/23rd-Web-Team-1-FE/assets/75570915/871e3488-7db5-45ee-8f9e-be189af24c4b">

### 오류 해결
- tsconfig.ts 파일 수정
- node 서버에서 api url은 상수값 사용하도록 수정

<br />

## 반영 화면

```
yarn dev:mock
```
![스크린샷 2024-01-18 오전 12 27 56](https://github.com/YAPP-Github/23rd-Web-Team-1-FE/assets/75570915/014e760f-bd10-44f4-9d35-5c943606173a)

<!-- 작업 내용이 반영된 화면을 붙여넣어주세요 -->

<!--

| **AS-IS** | **TO-BE** |
|:---:|:---:|
| x | y |

영상
<video src="" style="width:25%;" />

이미지
<img src="" style="width:25%;" /> 

-->


<br />

## 기타

- n/a
