### PR TITLE
fix: [LINKER-103] Profile 컴포넌트 size prop 추가 및 imageUrl prop 이름 수정

### DIFF
--- a/packages/lds/src/Profile/Profile.stories.tsx
+++ b/packages/lds/src/Profile/Profile.stories.tsx
@@ -24,7 +24,7 @@ export const Template: Story = {
 
         {/* 샘플 이미지 */}
         <Profile
-          profileImgUrl="https://static.im-linker.com/images/profile-sample.png"
+          imageUrl="https://static.im-linker.com/images/profile-sample.png"
           alt="샘플 이미지"
         />
       </>

--- a/packages/lds/src/Profile/Profile.tsx
+++ b/packages/lds/src/Profile/Profile.tsx
@@ -5,22 +5,32 @@ import Image, { ImageProps } from 'next/image';
 
 import { profile } from './Profile.css';
 
+const PROFILE_SIZE = {
+  xLarge: 64,
+  large: 56,
+  medium: 48,
+  small: 36,
+};
+
+type ProfileSize = keyof typeof PROFILE_SIZE;
+
 interface Props extends Omit<ImageProps, 'src' | 'alt'> {
-  profileImgUrl?: string;
+  imageUrl?: string;
   alt?: string;
   className?: string;
+  size?: ProfileSize;
 }
 
 const PROFILE_DEFAULT_IMAGE_URL = 'https://static.im-linker.com/images/profile-default.png';
 
-const Profile = ({ profileImgUrl, alt = '', className, ...props }: Props) => {
+const Profile = ({ imageUrl, alt = '', className, size = 'large', ...props }: Props) => {
   return (
     <Image
-      src={profileImgUrl ?? PROFILE_DEFAULT_IMAGE_URL}
-      blurDataURL={profileImgUrl ?? PROFILE_DEFAULT_IMAGE_URL}
+      src={imageUrl ?? PROFILE_DEFAULT_IMAGE_URL}
+      blurDataURL={imageUrl ?? PROFILE_DEFAULT_IMAGE_URL}
       alt={alt === '' ? '기본 프로필 이미지' : alt}
-      width={64}
-      height={64}
+      width={PROFILE_SIZE[size]}
+      height={PROFILE_SIZE[size]}
       placeholder="blur"
       className={clsx(profile, className)}
       {...props}


### PR DESCRIPTION
## 작업 내용

<!-- 작업한 내용을 적어주세요 -->

- [x] 피그마 디자인시스템 size와 동일하게 적용

![스크린샷 2024-02-03 오전 12 08 05](https://github.com/YAPP-Github/23rd-Web-Team-1-FE/assets/75570915/d44c6210-53a4-4f93-877f-ca4b43683497)

<br />

## 반영 화면

<!-- 작업 내용이 반영된 화면을 붙여넣어주세요 -->

<!--

| **AS-IS** | **TO-BE** |
|:---:|:---:|
| x | y |

영상
<video src="" style="width:25%;" />

이미지
<img src="" style="width:25%;" /> 

-->


<br />

## 기타

- n/a
