### PR TITLE
fix: [LINKER-131] 연락처 검색화면 css수정

### DIFF
--- a/packages/lds/src/SearchInput/SearchInput.css.ts
+++ b/packages/lds/src/SearchInput/SearchInput.css.ts
@@ -20,6 +20,7 @@ export const searchInput = style({
   border: 'none',
   background: 'none',
   backgroundColor: 'transparent',
+  color: `${colors.gray500}`,
   outline: 'none',
   cursor: 'pointer',
   '::placeholder': {

--- a/services/web/src/app/contactSearch/component/ContactSearch/ContactSearch.css.ts
+++ b/services/web/src/app/contactSearch/component/ContactSearch/ContactSearch.css.ts
@@ -5,7 +5,7 @@ export const container = style({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
-  height: '100vw',
+  height: '100vh',
   paddingLeft: '2rem',
   paddingRight: '2rem',
   paddingTop: '2rem',
@@ -30,8 +30,8 @@ export const searchWrapper = style({
 });
 
 export const nullSearchItemWrapper = style({
-  width: '100%',
-  height: '100vh',
+  height: 'calc(100vh - 44px)',
+  overflowY: 'auto',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',

--- a/services/web/src/app/my/contact/component/ContactDefault/ContactDefault.css.ts
+++ b/services/web/src/app/my/contact/component/ContactDefault/ContactDefault.css.ts
@@ -9,7 +9,7 @@ export const favoritesWrapper = style({
 export const favoritesTextWrapper = style({
   display: 'flex',
   flexDirection: 'row',
-  gap: '1px',
+  gap: '4px',
 });
 export const favoriteDropDown = style({
   cursor: 'pointer',

--- a/services/web/src/app/my/contact/component/ContactDefault/ContactDefault.tsx
+++ b/services/web/src/app/my/contact/component/ContactDefault/ContactDefault.tsx
@@ -38,9 +38,11 @@ export default function ContactDefault({ defaultContact, bookmarksContact }: Pro
             {bookmarksContact.length}
           </Txt>
         </div>
-        <button className={favoriteDropDown} onClick={onFavoriteClick}>
-          {isClickFavorites ? <Icon name="down" size={24} /> : <Icon name="up" size={24} />}
-        </button>
+        {bookmarksContact.length > 0 ? (
+          <button className={favoriteDropDown} onClick={onFavoriteClick}>
+            {isClickFavorites ? <Icon name="down" size={24} /> : <Icon name="up" size={24} />}
+          </button>
+        ) : null}
       </article>
       <article className={profileWrapper}>
         {isClickFavorites &&


### PR DESCRIPTION
## 작업 내용

<img width="770" alt="image" src="https://github.com/YAPP-Github/23rd-Web-Team-1-FE/assets/85864699/9873a922-9802-4625-bf7f-d22fd394da55">  



- 지인 이름 검색해보세요 가운데로
- height의 크기 수정
- 검색할때 텍스트 입력시 하얀색으로 바뀌는 문제 수정
- +) 추가적으로 북마크된 연락처가 한개일때 토글 안생기게 수정